### PR TITLE
Improve error handling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -84,7 +84,7 @@ See the accompanying LICENSE file for terms.
 
 			// Determine if the `date` is valid.
 			if (!(date && date.getTime())) {
-				throw new TypeError('A date must be provided.');
+				return '';
 			}
 
 			if (!options) {
@@ -111,7 +111,7 @@ See the accompanying LICENSE file for terms.
 
 		function intlNumber(num, formatOptions, options) {
 			if (typeof num !== 'number') {
-				throw new TypeError('A number must be provided.');
+				return '';
 			}
 
 			if (!options) {


### PR DESCRIPTION
## Problem

When `foo` is `undefined` `{{intlNumber foo}}` will throw and everything dies. `{{intlDate}}` too.

## Solution

Instead of `throw` just `return ''`. Works great, doesn't explode.